### PR TITLE
[#25] Fix destroy comment reload

### DIFF
--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -5,7 +5,7 @@
 
     <% if comment.user == current_user %>
       <%= link_to "Edit", edit_article_comment_path(comment.article, comment), class: "button" %>
-      <%= button_to 'Delete', [comment.article, comment], method: :delete, data: { confirm: 'Are you sure?' }, class: 'button button--danger' %>
+      <%= button_to 'Delete', [comment.article, comment], method: :delete, data: { confirm: 'Are you sure?' }, class: 'button button--danger', form: { data: { turbo_frame: "_top" } } %>
     <% end %>
   <% end %>
   <% if user_signed_in? %>


### PR DESCRIPTION
This fix restores the prior functionality of the destroy comment button reloading the entire page and showing a "Comment was successfully destroyed." message. 

When I implemented the turbo frame around the entire comment partial, the turbo frame basically overwrote the existing `redirect_to @article` in the destroy route of the comments controller, and thus turbo tried to replace just the frame which led to the "content missing" bug.