### PR TITLE
[#28] Make reply form into a turbo frame

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -49,6 +49,14 @@ class CommentsController < ApplicationController
     end
   end
 
+  def reply
+    @article = Article.find(params[:article_id])
+    @parent_comment = Comment.find(params[:id])
+    @comment = Comment.new(parent_id: @parent_comment.id)
+
+    render partial: "comments/form", locals: { article: @article, comment: @comment, form_class: "reply" }
+  end
+
 
   private
     # Use callbacks to share common setup or constraints between actions.

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -9,9 +9,10 @@
     <% end %>
   <% end %>
   <% if user_signed_in? %>
-    <!-- Reply form -->
-    reply
-    <%= render 'comments/form', article: comment.article, comment: Comment.new(parent_id: comment.id), form_class: "reply" %>    <% end %>
+    <%= turbo_frame_tag "reply_form_for_comment_#{comment.id}" do %>
+      <%= link_to "Reply", reply_article_comment_path(comment.article, comment), class: "button" %>
+    <% end %>
+  <% end %>
 
   <% comment.replies.each do |reply| %>
     <div class="reply" style="margin-left: 30px;">

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,21 +1,47 @@
-<%= form_with(model: [article, comment || Comment.new], local: true, class: "comment-form #{form_class}") do |form| %>
-  <%= form.hidden_field :parent_id %>
-  <% if comment&.errors&.any? %>
-    <div class="form-errors">
-      <h2><%= pluralize(comment.errors.count, "error") %> prohibited this comment from being saved:</h2>
-      <ul>
-        <% comment.errors.full_messages.each do |msg| %>
-          <li><%= msg %></li>
-        <% end %>
-      </ul>
+<% if form_class == "reply" %>
+  <%= turbo_frame_tag "reply_form_for_comment_#{comment.parent_id}" do %>
+    <%= form_with(model: [article, comment || Comment.new], data: { turbo_frame: "_top" }, local: true, class: "comment-form #{form_class}") do |form| %>
+      <%= form.hidden_field :parent_id %>
+      <% if comment&.errors&.any? %>
+        <div class="form-errors">
+          <h2><%= pluralize(comment.errors.count, "error") %> prohibited this comment from being saved:</h2>
+          <ul>
+            <% comment.errors.full_messages.each do |msg| %>
+              <li><%= msg %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+      <div class="form-field">
+        <%= form.label :body, class: "form-label" %>
+        <%= form.text_area :body, class: "form-input", required: true %>
+      </div>
+
+      <div class="form-actions">
+        <%= form.submit "Add Reply", class: "button" %>
+      </div>
+    <% end %>
+  <% end %>
+<% else %>
+  <%= form_with(model: [article, comment || Comment.new], local: true, class: "comment-form #{form_class}") do |form| %>
+    <%= form.hidden_field :parent_id %>
+    <% if comment&.errors&.any? %>
+      <div class="form-errors">
+        <h2><%= pluralize(comment.errors.count, "error") %> prohibited this comment from being saved:</h2>
+        <ul>
+          <% comment.errors.full_messages.each do |msg| %>
+            <li><%= msg %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+    <div class="form-field">
+      <%= form.label :body, class: "form-label" %>
+      <%= form.text_area :body, class: "form-input", required: true %>
+    </div>
+
+    <div class="form-actions">
+      <%= form.submit "Add Comment", class: "button" %>
     </div>
   <% end %>
-  <div class="form-field">
-    <%= form.label :body, class: "form-label" %>
-    <%= form.text_area :body, class: "form-input", required: true %>
-  </div>
-
-  <div class="form-actions">
-    <%= form.submit "Add Comment", class: "button" %>
-  </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 Rails.application.routes.draw do
   devise_for :users
   resources :articles do
-    resources :comments, only: [ :create, :destroy, :update, :edit ]
+    resources :comments, only: [ :create, :destroy, :update, :edit ] do
+      get "reply", on: :member
+    end
   end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/spec/features/comment_spec.rb
+++ b/spec/features/comment_spec.rb
@@ -104,10 +104,13 @@ RSpec.describe 'Comment Replies', type: :feature do
 
   it 'allows a user to reply to a comment' do
     visit article_path(article)
+    save_and_open_page
+    puts page.body
+    click_link 'Reply'
 
     within(".comment-form.reply") do
       fill_in 'Body', with: 'This is a reply'
-      click_button 'Add Comment'
+      click_button 'Add Reply'
     end
 
     expect(page).to have_content('This is a reply')


### PR DESCRIPTION
I made a new controller and route `reply` to render the partial comments form for replies so that I could put the reply button into a turbo frame with a reply path and connect it to a turbo frame around the comments form. Since I only want the turbo frame around the form for replies and not for top level comments I basically duplicated the form with an `if else` for whether or not it should be put in a turbo frame. This isn't ideal- one solution would be to abstract the actual form into a `form_inner.html.erb` file then just have `<% if form_class == "reply"%>
  <%= turbo_frame_tag "reply_form_for_comment_#{comment.parent_id}" do %>
    <%= render 'comments/form_inner', article: article, comment: comment, form_class: form_class %>
  <% end %>
<% else %>
  <%= render 'comments/form_inner', article: article, comment: comment, form_class: form_class %>
<% end %>` 
But I wasn't sure about this refactor so left it as is for now, currently with the duplicate code I named the two submit buttons different things (`Add Comment` and `Add Reply`) and added `data: { turbo_frame: "_top" }` to the reply form to trigger a reload.

Screenshots:
![Screenshot 2025-07-07 at 4 16 08 PM](https://github.com/user-attachments/assets/9cc179a9-03df-40cc-8654-3b49ae4c0e33)
![Screenshot 2025-07-07 at 4 16 21 PM](https://github.com/user-attachments/assets/b99a1c0b-27b6-4540-aeb1-9d1b8e4809f8)
![Screenshot 2025-07-07 at 4 16 30 PM](https://github.com/user-attachments/assets/960ded61-906c-4a47-8934-6be5551885d3)